### PR TITLE
Expose Config and app via package init

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package exposing the FastAPI application instance."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Unit tests for the :mod:`api` package."""
+
+__all__: list[str] = []

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc \
+    gcc=4:12.2.0-3 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/indexer/__init__.py
+++ b/indexer/__init__.py
@@ -1,0 +1,5 @@
+"""Indexer package exposing configuration and indexing classes."""
+
+from .indexer import Config, FileIndexer
+
+__all__ = ["Config", "FileIndexer"]

--- a/indexer/tests/__init__.py
+++ b/indexer/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Unit tests for the :mod:`indexer` package."""
+
+__all__: list[str] = []

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,3 @@
+"""Integration tests for the project."""
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- export Config and FileIndexer from the indexer package
- expose FastAPI `app` at api package root and document test packages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'faker')*

------
https://chatgpt.com/codex/tasks/task_e_68a817a5008c8333bbd55705430b0df4