### PR TITLE
Ensure services wait for Manticore bootstrap

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -49,6 +49,8 @@ services:
     depends_on:
       manticore:
         condition: service_healthy
+      bootstrap:
+        condition: service_completed_successfully
     environment:
       - MANTICORE_URL=http://manticore:9308/sql
       - SCAN_ROOTS=/data
@@ -69,6 +71,8 @@ services:
     depends_on:
       manticore:
         condition: service_healthy
+      bootstrap:
+        condition: service_completed_successfully
     environment:
       - MANTICORE_URL=http://manticore:9308/sql
       - DEFAULT_PAGE_SIZE=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,8 @@ services:
     depends_on:
       manticore:
         condition: service_healthy
+      bootstrap:
+        condition: service_completed_successfully
     environment:
       - MANTICORE_URL=http://manticore:9308/sql
       - SCAN_ROOTS=${SCAN_ROOTS:-/data}
@@ -100,6 +102,8 @@ services:
     depends_on:
       manticore:
         condition: service_healthy
+      bootstrap:
+        condition: service_completed_successfully
     environment:
       - MANTICORE_URL=http://manticore:9308/sql
       - DEFAULT_PAGE_SIZE=${DEFAULT_PAGE_SIZE:-50}


### PR DESCRIPTION
## Summary
- prevent indexer and API containers from starting before the Manticore `files` table exists
- add bootstrap dependency to docker-compose files for both development and tests

## Testing
- `make test-unit`
- `make test-integration` *(fails: make: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a83b8a147c83338b97b96c3df72dc2